### PR TITLE
Update pnpm and refresh homepage visuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ tsconfig.tsbuildinfo
 _bmad/
 _bmad-output/
 .github/skills/
+
+# Harness
+docs/
+
+# ohmyopencode
+.sisyphus/
+
+# Next.js generated types
+next-env.d.ts

--- a/components/Content.tsx
+++ b/components/Content.tsx
@@ -9,11 +9,18 @@ interface ContentProps {
 
 export function Content({ content }: ContentProps) {
   return (
-    <main className="container pt-4 pl-2 pr-2 md:mx-auto xl:px-32 leading-loose">
+    <main
+      role="main"
+      className="container pt-4 pl-4 pr-4 md:mx-auto xl:px-32 leading-loose text-[var(--color-fg)] bg-[var(--color-bg)] min-h-screen font-mono"
+    >
       <div className="mt-16 max-w-[80%] mx-auto">
-        <h1 className="text-2xl font-bold mb-4">{content.document.title}</h1>
-        {/* HTML is sanitized at build time in lib/content.ts */}
-        <div className="content" dangerouslySetInnerHTML={{ __html: content.html }} />
+        <h1 className="text-2xl font-bold mb-6 text-[var(--color-accent)]">
+          <span className="text-[var(--color-accent)]/50">&gt;</span> {content.document.title}
+        </h1>
+        <div
+          className="adoc-content terminal-text"
+          dangerouslySetInnerHTML={{ __html: content.html }}
+        />
       </div>
     </main>
   )

--- a/components/Loading.tsx
+++ b/components/Loading.tsx
@@ -1,7 +1,7 @@
 export function Loading() {
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-600"></div>
+    <div className="flex h-screen w-full items-center justify-center bg-[var(--color-bg)]">
+      <div className="h-32 w-32 animate-spin rounded-full border-b-2 border-[var(--color-accent)]"></div>
     </div>
   )
 }

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -26,25 +26,25 @@ const NavigationLink = ({ href, children, onClick, isActive = false }: Navigatio
     href={href}
     onClick={onClick}
     className={`
-      text-gray-700 hover:text-gray-900 hover:underline focus:underline 
-      transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900
-      ${isActive ? 'underline text-gray-900 font-medium' : ''}
+      nav-link text-[var(--color-fg)] hover:text-[var(--color-accent)]
+      ${isActive ? 'text-[var(--color-accent)] font-bold' : 'opacity-80'}
     `}
     aria-current={isActive ? 'page' : undefined}
   >
+    {isActive ? '> ' : ''}
     {children}
   </Link>
 )
 
 const BurgerButton = ({ isOpen, onClick }: BurgerButtonProps) => {
-  const barBaseClasses = 'w-6 h-0.5 bg-gray-900 rounded transition-all duration-300'
+  const barBaseClasses = 'w-6 h-0.5 bg-[var(--color-accent)] rounded transition-all duration-300'
 
   return (
     <button
       aria-label={isOpen ? 'Close navigation' : 'Open navigation'}
       aria-expanded={isOpen}
       onClick={onClick}
-      className="h-8 w-8 flex flex-col justify-center items-center gap-1 sm:hidden mr-5 z-20 relative focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-900"
+      className="h-8 w-8 flex flex-col justify-center items-center gap-1 sm:hidden mr-5 z-20 relative focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
     >
       {/* Top bar - rotates to form top part of X */}
       <div
@@ -109,16 +109,17 @@ export default function Navigation() {
     <>
       {/* Main Navigation Header */}
       <header
-        className={`flex justify-end items-center sm:justify-center bg-gray-200 ${NAV_HEIGHT} w-full fixed top-0 ${NAV_Z_INDEX}`}
+        className={`flex justify-end items-center sm:justify-center bg-[var(--color-bg)]/90 backdrop-blur-sm border-b border-[var(--color-card-border)] ${NAV_HEIGHT} w-full fixed top-0 ${NAV_Z_INDEX}`}
       >
         <nav
           aria-label="Main navigation"
-          className="flex items-center w-full justify-end sm:justify-center"
+          className="flex items-center w-full justify-between sm:justify-center px-4"
         >
+          <div className="sm:hidden text-[var(--color-accent)] font-bold pl-2">maik.figura ~/</div>
           {/* Desktop Navigation */}
           <ul className="hidden sm:flex sm:flex-row">
             {navPages.map((page) => (
-              <li key={page} className="mx-4 text-2xl">
+              <li key={page} className="mx-4 text-xl">
                 <NavigationLink href={`/${page}`} isActive={isActivePage(page)}>
                   {page}
                 </NavigationLink>
@@ -134,7 +135,7 @@ export default function Navigation() {
       {/* Mobile Navigation Overlay */}
       <div
         className={`
-          fixed top-16 left-0 right-0 bottom-0 bg-gray-200 ${OVERLAY_Z_INDEX} sm:hidden 
+          fixed top-16 left-0 right-0 bottom-0 bg-[var(--color-bg)] ${OVERLAY_Z_INDEX} sm:hidden 
           transition-transform ${TRANSITION_DURATION}
           ${isOpen ? 'transform translate-x-0' : 'transform translate-x-full'}
         `}

--- a/e2e/about.spec.ts
+++ b/e2e/about.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+
+test.describe('About Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/about')
+  })
+
+  test('should render dark theme and terminal aesthetic', async ({ page }) => {
+    const main = page.locator('main')
+
+    await expect(main).toHaveCSS('font-family', /JetBrains Mono|Geist Mono|ui-monospace|monospace/)
+    await expect(main).toHaveCSS('background-color', 'rgb(15, 17, 26)')
+    await expect(main).toHaveCSS('color', 'rgb(212, 212, 212)')
+
+    const pre = page.locator('pre[aria-hidden="true"]')
+    await expect(pre).toBeVisible()
+    await expect(pre).toContainText('__')
+
+    const timeline = page.locator('.timeline-cards')
+    await expect(timeline).toBeVisible()
+    await expect(timeline.locator('p').first()).toBeVisible()
+  })
+
+  test('should pass a11y', async ({ page }) => {
+    const accessibilityScanResults = await new AxeBuilder({ page }).analyze()
+    expect(accessibilityScanResults.violations).toEqual([])
+  })
+})

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -4,10 +4,16 @@
   "description": "Personal homepage of Maik Figura - Chaos Engineer",
   "version": "1.0.0",
   "license": "MIT",
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.0.9+sha512.34ce82e6780233cf9cad8685029a8f81d2e06196c5a9bad98879f7424940c6817c4e4524fb7d38b8553ceed48b9758b8ebaf1abd3600c232c4c8cf7366086f38",
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.0.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   },
   "scripts": {
     "dev": "next dev --turbo",
@@ -35,6 +41,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "4.11.3",
+    "@biomejs/biome": "2.4.15",
     "@playwright/test": "1.59.1",
     "@tailwindcss/postcss": "4.2.4",
     "@testing-library/jest-dom": "6.9.1",
@@ -54,6 +61,7 @@
     "tailwindcss": "4.2.4",
     "typescript": "6.0.3",
     "typescript-eslint": "8.59.2",
+    "typescript-language-server": "5.2.0",
     "vitest": "4.1.5"
   }
 }

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -27,7 +27,7 @@ export default function Page({ content }: PageProps) {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => {
-  const slugs = getAllPageSlugs()
+  const slugs = getAllPageSlugs().filter((slug) => slug !== 'about')
 
   return {
     paths: slugs.map((slug) => ({

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,12 +1,15 @@
 import '../styles/globals.css'
 import type { AppProps } from 'next/app'
-import { Inter } from 'next/font/google'
+import { JetBrains_Mono, Inter } from 'next/font/google'
 
-const inter = Inter({ subsets: ['latin'] })
+const mono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono' })
+const inter = Inter({ subsets: ['latin'], variable: '--font-sans' })
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
-    <div className={inter.className}>
+    <div
+      className={`${mono.variable} ${inter.variable} font-mono bg-[var(--color-bg)] text-[var(--color-fg)] min-h-screen`}
+    >
       <Component {...pageProps} />
     </div>
   )

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -1,0 +1,126 @@
+import { SEO } from '@/components/SEO'
+import Navigation from '@/components/Navigation'
+import { getPageData, PageData } from '@/lib/content'
+import { siteConfig } from '@/lib/config'
+import { GetStaticProps } from 'next'
+
+interface AboutPageProps {
+  aboutContent: PageData
+  workContent: PageData
+}
+
+export default function AboutPage({ aboutContent, workContent }: AboutPageProps) {
+  if (!aboutContent || !workContent) {
+    return <div>Page not found</div>
+  }
+
+  return (
+    <>
+      <SEO
+        title={aboutContent.document.title}
+        canonical={`${siteConfig.headerMetadata.siteUrl}/${aboutContent.slug}`}
+      />
+      <Navigation />
+      <main
+        role="main"
+        className="ambient-shell relative isolate min-h-screen overflow-hidden pt-4 pl-4 pr-4 leading-loose text-[var(--color-fg)] bg-[var(--color-bg)] font-mono"
+      >
+        <h1 className="sr-only">About Maik Figura</h1>
+        <div className="relative z-10 mt-16 mx-auto max-w-6xl px-0 md:px-8 xl:px-16">
+          <section className="terminal-panel mb-12 overflow-hidden rounded-sm">
+            <div className="px-4 py-8 md:px-8 md:py-10">
+              <p className="mb-4 text-xs uppercase tracking-[0.35em] text-[var(--color-accent)]/70">
+                system architect / resilient software / human-centered craft
+              </p>
+              <pre
+                aria-hidden="true"
+                className="hero-ascii max-w-full text-[var(--color-accent)] leading-none overflow-x-auto whitespace-pre"
+              >
+                {`
+ __  __    _    ___ _  __   _____ ___  ____ _   _ ____      _    
+|  \\/  |  / \\  |_ _| |/ /  |  ___|_ _|/ ___| | | |  _ \\    / \\   
+| |\\/| | / _ \\  | || ' /   | |_   | || |  _| | | | |_) |  / _ \\  
+| |  | |/ ___ \\ | || . \\   |  _|  | || |_| | |_| |  _ <  / ___ \\ 
+|_|  |_/_/   \\_\\___|_|\\_\\  |_|   |___|\\____|\\___/|_| \\_\\/_/   \\_\\
+`}
+              </pre>
+              <p className="mt-6 max-w-3xl text-sm text-[var(--color-fg)]/75 md:text-base">
+                maik@figura:~$ building resilient systems with domain language, observability, and a
+                bias for useful software{' '}
+                <span className="terminal-caret text-[var(--color-accent)]">_</span>
+              </p>
+            </div>
+          </section>
+
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-16 border-t border-b border-[var(--color-accent)]/30 py-8">
+            <div className="stat-card terminal-panel rounded-sm transition-transform duration-300 hover:-translate-y-1">
+              <div className="stat-card-value">10</div>
+              <div className="stat-card-label">Years Exp</div>
+            </div>
+            <div className="stat-card terminal-panel rounded-sm transition-transform duration-300 hover:-translate-y-1">
+              <div className="stat-card-value">People</div>
+              <div className="stat-card-label">Before systems</div>
+            </div>
+            <div className="stat-card terminal-panel rounded-sm transition-transform duration-300 hover:-translate-y-1">
+              <div className="stat-card-value">Resilience</div>
+              <div className="stat-card-label">By design</div>
+            </div>
+            <div className="stat-card terminal-panel rounded-sm transition-transform duration-300 hover:-translate-y-1">
+              <div className="stat-card-value">Collaboration</div>
+              <div className="stat-card-label">Before Processes</div>
+            </div>
+          </div>
+
+          <div className="grid md:grid-cols-2 gap-12">
+            <div>
+              <h2 className="text-2xl font-bold mb-6 text-[var(--color-accent)]">
+                <span className="text-[var(--color-accent)]/50">&gt;</span> whoami
+              </h2>
+              <div
+                className="adoc-content terminal-text"
+                dangerouslySetInnerHTML={{ __html: aboutContent.html }}
+              />
+            </div>
+
+            <div>
+              <h2 className="text-2xl font-bold mb-6 text-[var(--color-accent)]">
+                <span className="text-[var(--color-accent)]/50">&gt;</span> cat experience.log
+              </h2>
+              <div className="space-y-6">
+                <div
+                  className="adoc-content timeline-cards"
+                  dangerouslySetInnerHTML={{ __html: workContent.html }}
+                />
+              </div>
+            </div>
+          </div>
+
+          <footer className="mt-16 border-t border-[var(--color-card-border)] py-8 text-sm text-[var(--color-fg)]/70">
+            <p>
+              maik@figura:~$ open collaboration.log{' '}
+              <span className="terminal-caret text-[var(--color-accent)]">_</span>
+            </p>
+          </footer>
+        </div>
+      </main>
+    </>
+  )
+}
+
+export const getStaticProps: GetStaticProps<AboutPageProps> = async () => {
+  const aboutContent = getPageData('about')
+  const workContent = getPageData('work')
+
+  if (!aboutContent || !workContent) {
+    return {
+      notFound: true,
+    }
+  }
+
+  return {
+    props: {
+      aboutContent,
+      workContent,
+    },
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@axe-core/playwright':
         specifier: 4.11.3
         version: 4.11.3(playwright-core@1.59.1)
+      '@biomejs/biome':
+        specifier: 2.4.15
+        version: 2.4.15
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
@@ -84,6 +87,9 @@ importers:
       typescript-eslint:
         specifier: 8.59.2
         version: 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      typescript-language-server:
+        specifier: 5.2.0
+        version: 5.2.0
       vitest:
         specifier: 4.1.5
         version: 4.1.5(@types/node@24.12.0)(@vitest/ui@4.1.5)(jsdom@29.1.1)(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0))
@@ -156,6 +162,63 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.15':
+    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.15':
+    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.15':
+    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.15':
+    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.15':
+    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.15':
+    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -2022,6 +2085,11 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
+  typescript-language-server@5.2.0:
+    resolution: {integrity: sha512-K+Fu46SgN+bzh0sbKk04hFHq0kWCljvBN9iHx6ej6pXHigrV6H9W/LENIliEkiUVoymiLmEotEBE2XHYnQCo1w==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2139,6 +2207,20 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  vscode-jsonrpc@5.0.1:
+    resolution: {integrity: sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==}
+    engines: {node: '>=8.0.0 || >=10.0.0'}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -2273,6 +2355,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/biome@2.4.15':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.15
+      '@biomejs/cli-darwin-x64': 2.4.15
+      '@biomejs/cli-linux-arm64': 2.4.15
+      '@biomejs/cli-linux-arm64-musl': 2.4.15
+      '@biomejs/cli-linux-x64': 2.4.15
+      '@biomejs/cli-linux-x64-musl': 2.4.15
+      '@biomejs/cli-win32-arm64': 2.4.15
+      '@biomejs/cli-win32-x64': 2.4.15
+
+  '@biomejs/cli-darwin-arm64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.15':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.15':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.15':
+    optional: true
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -3935,6 +4052,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  typescript-language-server@5.2.0:
+    dependencies:
+      vscode-jsonrpc: 5.0.1
+      vscode-languageserver-protocol: 3.17.5
+
   typescript@6.0.3: {}
 
   uglify-js@3.19.3:
@@ -4002,6 +4124,17 @@ snapshots:
       - msw
 
   void-elements@3.1.0: {}
+
+  vscode-jsonrpc@5.0.1: {}
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-types@3.17.5: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  esbuild: true
+  sharp: true

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,17 +1,214 @@
 @import 'tailwindcss';
 
+@theme {
+  --color-bg: #0f111a;
+  --color-fg: #d4d4d4;
+  --color-accent: #22c55e;
+  --color-card-bg: #161b22;
+  --color-card-border: #30363d;
+
+  --font-mono:
+    'JetBrains Mono', 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    'Liberation Mono', 'Courier New', monospace;
+}
+
 @layer base {
   html {
-    @apply bg-gray-50 font-sans antialiased;
+    @apply bg-[var(--color-bg)] text-[var(--color-fg)] font-mono antialiased;
+  }
+
+  body {
+    @apply bg-[var(--color-bg)] text-[var(--color-fg)];
   }
 
   h2 {
-    @apply pt-4 text-xl font-bold;
+    @apply pt-4 text-xl font-bold text-[var(--color-accent)];
+  }
+
+  ::selection {
+    @apply bg-[var(--color-accent)] text-black;
   }
 }
 
 @layer components {
-  .content ul {
-    @apply list-disc;
+  .ambient-shell {
+    background-color: var(--color-bg);
+    background-image:
+      radial-gradient(circle at 15% 10%, rgb(34 197 94 / 0.12), transparent 24rem),
+      radial-gradient(circle at 85% 0%, rgb(212 212 212 / 0.06), transparent 20rem),
+      linear-gradient(rgb(34 197 94 / 0.045) 1px, transparent 1px),
+      linear-gradient(90deg, rgb(34 197 94 / 0.04) 1px, transparent 1px);
+    background-size:
+      auto,
+      auto,
+      44px 44px,
+      44px 44px;
+  }
+
+  .ambient-shell::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background: repeating-linear-gradient(
+      180deg,
+      rgb(212 212 212 / 0.035) 0,
+      rgb(212 212 212 / 0.035) 1px,
+      transparent 1px,
+      transparent 4px
+    );
+    mix-blend-mode: screen;
+    opacity: 0.38;
+  }
+
+  .terminal-panel {
+    @apply border border-[var(--color-card-border)] bg-[var(--color-card-bg)]/70 shadow-2xl shadow-black/30 backdrop-blur-sm;
+  }
+
+  .terminal-panel::before {
+    content: 'maik.figura ~/about';
+    @apply block border-b border-[var(--color-card-border)] px-4 py-2 text-xs text-[var(--color-accent)]/80;
+    background: linear-gradient(90deg, rgb(34 197 94 / 0.1), transparent);
+  }
+
+  .hero-ascii {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    padding-bottom: 0.25rem;
+    font-size: clamp(0.36rem, 1.65vw, 1rem);
+    scrollbar-width: thin;
+    animation: terminal-reveal 1.4s steps(34, end) both;
+    filter: drop-shadow(0 0 18px rgb(34 197 94 / 0.28));
+  }
+
+  .terminal-caret {
+    animation: terminal-blink 1s steps(2, start) infinite;
+  }
+
+  .stat-card {
+    @apply flex min-h-28 flex-col justify-start px-4 pb-4 pt-5 md:min-h-32 md:px-5 md:pb-4 md:pt-7 xl:px-6;
+  }
+
+  .stat-card-value {
+    @apply text-[var(--color-accent)] font-bold leading-tight tracking-tight;
+    font-size: clamp(1.25rem, 1.85vw, 1.7rem);
+    text-wrap: balance;
+  }
+
+  @media (width >= 64rem) {
+    .stat-card-value {
+      letter-spacing: -0.035em;
+    }
+  }
+
+  .stat-card-label {
+    @apply mt-2 text-xs uppercase text-gray-400 sm:text-sm;
+    letter-spacing: 0.11em;
+  }
+
+  @media (width >= 40rem) {
+    .stat-card-label {
+      letter-spacing: 0.18em;
+    }
+  }
+
+  .nav-link {
+    @apply relative inline-flex items-center no-underline transition-all duration-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)];
+  }
+
+  .nav-link::after {
+    content: '';
+    @apply absolute -bottom-1 left-0 h-px w-full origin-left scale-x-0 bg-[var(--color-accent)] transition-transform duration-300;
+  }
+
+  .nav-link:hover::after,
+  .nav-link:focus-visible::after,
+  .nav-link[aria-current='page']::after {
+    @apply scale-x-100;
+  }
+
+  .nav-link:hover {
+    text-shadow: 0 0 16px rgb(34 197 94 / 0.45);
+  }
+
+  .adoc-content ul {
+    @apply list-none pl-0;
+  }
+
+  .adoc-content li {
+    @apply relative pl-4 mb-2;
+  }
+
+  .adoc-content li::before {
+    content: '>';
+    @apply absolute left-0 text-[var(--color-accent)] font-bold;
+  }
+
+  .adoc-content a {
+    @apply text-[var(--color-accent)] underline underline-offset-4 decoration-[var(--color-accent)]/30 hover:decoration-[var(--color-accent)];
+  }
+
+  .adoc-content p {
+    @apply mb-4 leading-relaxed;
+  }
+
+  .timeline-cards h2 {
+    @apply text-sm text-[var(--color-accent)]/80 mb-2 mt-6 pt-0 font-normal;
+  }
+
+  .timeline-cards p {
+    @apply bg-[var(--color-card-bg)]/85 border border-[var(--color-card-border)] p-4 rounded-sm text-sm mb-0 relative transition-all duration-300;
+  }
+
+  .timeline-cards p:hover {
+    @apply -translate-y-1 border-[var(--color-accent)]/50 shadow-lg shadow-[var(--color-accent)]/10;
+  }
+
+  .timeline-cards p::before {
+    content: '';
+    @apply absolute left-0 top-0 bottom-0 w-1 bg-[var(--color-accent)]/50;
+  }
+
+  .timeline-cards p strong {
+    @apply inline text-[var(--color-fg)] font-bold;
+  }
+
+  .terminal-text p {
+    @apply opacity-90;
+  }
+}
+
+@keyframes terminal-reveal {
+  from {
+    clip-path: inset(0 100% 0 0);
+    opacity: 0.3;
+  }
+  to {
+    clip-path: inset(0 0 0 0);
+    opacity: 1;
+  }
+}
+
+@keyframes terminal-blink {
+  0%,
+  45% {
+    opacity: 1;
+  }
+  46%,
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
   }
 }


### PR DESCRIPTION
## Summary
- Update the project to pnpm 11.0.9 with pnpm 11 build approvals for esbuild and sharp.
- Refresh the homepage/about-page terminal styling and navigation presentation.
- Add Playwright coverage for the about page visual/a11y surface.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm validate`
- `pnpm build`
- `pnpm exec playwright test e2e/about.spec.ts --reporter=list`
- Manual browser QA against production server: `/about` rendered, Work navigation clicked through, bad route returned/rendered 404, no console errors before the intentional 404.
