### PR TITLE
🔒 Add pnpm supply-chain cooldown (minimumReleaseAge 3 days)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":pinAllExceptPeerDependencies"],
   "commitMessagePrefix": "⬆️",
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
   "updateNotScheduled": true,
   "lockFileMaintenance": {
     "enabled": true,

--- a/package.json
+++ b/package.json
@@ -6,14 +6,8 @@
   "license": "MIT",
   "packageManager": "pnpm@11.6.0+sha512.9a36518224080c6fe5165afdcfe79bfa118c29be703f3f462b1e32efe1e98e47e8750b148e08286250aad4113cc7993ca413c4e2cd447752708c2ee5751bc95f",
   "engines": {
-    "node": ">=24.0.0",
+    "node": "24.x",
     "pnpm": ">=11.0.0"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
   },
   "scripts": {
     "dev": "next dev --turbo",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+# 4320 min = 3 days. Keep in sync with renovate.json minimumReleaseAge.
+minimumReleaseAge: 4320
+
 allowBuilds:
   esbuild: true
   sharp: true


### PR DESCRIPTION
## Why

Renovate PR #313 (dompurify@3.4.10) failed Vercel's build with:

```
[ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION]
  dompurify@3.4.10 was published within the minimumReleaseAge cutoff
```

pnpm v11 ships a default supply-chain cooldown of **1 day** (`minimumReleaseAge: 1440`). Renovate has no cooldown, so it opens PRs (and commits lockfiles) the moment a version is published — before pnpm's policy will accept it. The two systems disagree, and the build fails.

## What

Align both systems on a **3-day** cooldown so Renovate never raises a PR that pnpm's lockfile verification will reject:

- **pnpm-workspace.yaml**: `minimumReleaseAge: 4320` (3 days)
- **.github/renovate.json**: `minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"` (holds PRs pending until the release age clears)

Also silences the two unrelated Vercel build warnings from the same log:

- **package.json**: pin `engines.node` to `"24.x"` (stops the auto-upgrade warning) and drop the `pnpm.onlyBuiltDependencies` field that pnpm v11 ignores (already migrated to `allowBuilds` in pnpm-workspace.yaml)

## Follow-up

Closing #313 — Renovate will re-raise the dompurify bump automatically once the version is 3 days old, and it will pass cleanly.