### PR TITLE
🔒 Lower pnpm cooldown net to 2 days (below Renovate's 3-day gate)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
-# 4320 min = 3 days. Keep in sync with renovate.json minimumReleaseAge.
-minimumReleaseAge: 4320
+# 2880 min = 2 days: safety net kept below renovate.json's 3-day gate.
+minimumReleaseAge: 2880
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
## Why

Follow-up to #317. That PR set **both** pnpm and Renovate to a 3-day `minimumReleaseAge`. Identical windows create a boundary race: Renovate raises the PR at the 3-day mark and regenerates the lockfile at that same instant, while pnpm's net is also 3 days — which is what produces the `renovate/artifacts` "Artifact file update failure" and flaky installs.

## What

Lower pnpm's net to **2 days** (`2880`), keeping Renovate's gate at **3 days**.

- **Renovate (3 days)** = gatekeeper — holds the PR until the dep is mature.
- **pnpm (2 days)** = safety net — always cleared with ~1 day of margin by the time CI/Vercel run `pnpm install --frozen-lockfile`.

Rule: pnpm's window stays **strictly below** Renovate's, so every Renovate-raised PR is comfortably past pnpm's policy and installs cleanly. The 2-day net still protects manual/non-Renovate bumps.